### PR TITLE
Add CI/CD pipeline

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,0 +1,45 @@
+name: Publish to NPM
+
+on:
+  # Workflow will be activated when pushing a version tag to github
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      # Setup (checkout and use Node)
+      - uses: actions/checkout@v3
+      - name: Use Node.js 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      # Install
+      - name: Install main repo dependencies
+        run: npm install
+
+      - name: Install example repo dependencies
+        run: npm run example-repo-install
+
+      # Test
+      - name: Run jest tests
+        run: npm run test-jest
+
+      - name: Run scripts tests
+        run: npm run example-repo-run-test-scripts
+
+      # Build
+      - name: Build package
+        run: npm run build
+
+      # Publish
+      - name: Publish to NPM
+        # run: npm publish
+        run: npm publish --dry-run # used for testing purposes
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.PUBLISH_ENVTUNE_NPM_WORKFLOW_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -233,6 +233,40 @@ npm run install-local-package
 npm run test-all-scripts
 ```
 
+## CI/CD Pipeline & Publishing to NPM Registry
+
+Publishing a new entune package version to the NPM registry is automated via bash scripts and github actions / workflows.
+
+### Publish Process
+
+1. Make sure you've synced with `master` branch and have checked out the commit you want to publish a new version for
+2. Intiate the publishing new version process:
+
+```bash
+# Grant permission to the shell script
+chmod +x publish-new-version.sh
+
+# Run the publishing new version process
+npm run publish-new-version
+```
+
+You will be prompted to enter the semantic versioning type (major, minor, patch), as well as verify you want to publish a new version, for the process to complete. This script will run all tests, create a new commit on GitHub, and push a new version tag for that commit, which will in turn automatically activate the `publish-to-npm.yml` workflow and publish the new version to the NPM Registry.
+
+### Cancelling the Publish Process
+
+To cancel the publish process, just type `no` when asked if you are certain you want to proceed, and the script will automatically revert all changes.
+
+### Testing the CI/CD Pipeline
+
+To test the entire CI/CD pipeline:
+
+1. Make sure you have checked out and are working on a feature branch
+2. Add the `--dry-run` flag in the `npm publish` step of the `publish-to-npm.yml` GitHub workflow, to prevent from actually publishing but still have meaningful terminal output to diagnose the process.
+3. After test-running the publish process, a manual cleanup is necessary:
+   1. Delete the newly created and pushed by the script version tag, from both your local `git tag -d <tag_name>` and remote branch `git push origin --delete <tag_name>`
+   2. Run `git reset HEAD~1 --hard` to reset your local branch to the previous commit, and completely remove all files created by the test process
+   3. Run `git push origin <branch_name> --force` to force-push your local branch to remote, which will effectively remove all files created by the test process in the remote branch as well
+
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -66,9 +66,9 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@types/node": {
-      "version": "20.8.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.9.tgz",
-      "integrity": "sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==",
+      "version": "20.8.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
       "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -125,7 +125,7 @@
     "node_modules/envtune": {
       "version": "1.1.3",
       "resolved": "file:envtune-latest.tgz",
-      "integrity": "sha512-x7vAKvZGTmVftjEJAXRf0wl9OcgwHg+1zVnAYLpG9z4x69meDQus4/vD/6TF7UbJyF6K3bFPsnVYJhRfyi0h0w==",
+      "integrity": "sha512-nyQGIQoaCEF8FXMHNCIl6vuanjhTOunDhXe6gQoy/6DDBzd5JzRvu0Lx1ePkV/IFr7g8wFAQzgzdAbWNW4J+Gw==",
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.3.1",

--- a/example/scripts/install-local-package.sh
+++ b/example/scripts/install-local-package.sh
@@ -1,21 +1,34 @@
 #!/bin/bash
+source ../scripts/log-to-terminal.sh
 
-cd ..
-echo -e $'\e[33m\n[install-local-package.sh]\nBuilding current envtune version\n\e[0m'
-npm run build
+log "Executing" "" "standout"
 
-echo -e $'\e[33m\n[install-local-package.sh]\nGenerating tarball file for current envtune version\n\e[0m'
-npm pack
+(
+  cd ..
+  log "Building current envtune version"
+  npm run build
 
-TARBALL=$(ls *.tgz)
-echo -e $'\e[33m\n[install-local-package.sh]\nGenerated tarball file \e[0m\e[33m'${TARBALL}$'\n\e[0m'
+  log "Generating tarball file for current envtune version"
+  npm pack
 
-echo -e $'\e[33m\n[install-local-package.sh]\nMoving and renaming generated tarball file to `example` directory\n\e[0m'
-mv "${TARBALL}" "example/envtune-latest.tgz"
+  TARBALL=$(ls *.tgz)
+  log "Generated tarball file $TARBALL"
 
-cd example
-echo -e $'\e[33m\n[install-local-package.sh]\nRemoving any existing envtune dependency from `example` repo\n\e[0m'
-npm remove envtune
+  log "Moving and renaming generated tarball file to 'example' directory"
+  mv "${TARBALL}" "example/envtune-latest.tgz"
 
-echo -e $'\e[33m\n[install-local-package.sh]\nInstalling generated tarball as dependency in `example` repo\n\e[0m'
-npm install "./envtune-latest.tgz"
+  cd example
+  log "Removing any existing envtune dependency from 'example' repo"
+  npm remove envtune
+
+  log "Installing generated tarball as dependency in 'example' repo"
+  npm install "./envtune-latest.tgz"
+)
+
+if [ $? -eq 0 ]; then
+  log "Installation completed successfully" "success"
+else
+  log "Installation failed" "error"
+fi
+
+log "Execution completed" "" "standout"

--- a/example/scripts/test-all-scripts.sh
+++ b/example/scripts/test-all-scripts.sh
@@ -1,81 +1,32 @@
 #!/bin/bash
+source ../scripts/log-to-terminal.sh
 
-# Test 1: `npm run envtune:default-envtunerc`
-echo -e $'\e[33m\n[test-all-scripts.sh] - Test 1: `npm run envtune:default-envtunerc` RUNNING\e[0m'
-expected1="hushHushDev"
-output1=$(npm run envtune:default-envtunerc 2>&1)
-if [[ "$output1" == *"$expected1"* ]]; then
-  echo -e $'\e[32m[test-all-scripts.sh] - Test 1: `npm run envtune:default-envtunerc` PASSED\e[0m'
-else
-  echo -e $'\e[31m[test-all-scripts.sh] - Test 1: `npm run envtune:default-envtunerc` FAILED\e[0m'
-fi
+log "Executing" "" "standout"
 
-# Test 2: `npm run envtune:ts-es6`
-echo -e $'\e[33m\n[test-all-scripts.sh] - Test 2: `npm run envtune:ts-es6` RUNNING\e[0m'
-expected2="hushHushDev"
-output2=$(npm run envtune:ts-es6 2>&1)
-if [[ "$output2" == *"$expected2"* ]]; then
-  echo -e $'\e[32m[test-all-scripts.sh] - Test 2: `npm run envtune:ts-es6` PASSED\e[0m'
-else
-  echo -e $'\e[31m[test-all-scripts.sh] - Test 2: `npm run envtune:ts-es6` FAILED\e[0m'
-fi
+run_test() {
+  local test_number=$1
+  local test_command=$2
+  local expected_output=$3
+  
+  log "Test $test_number: '$test_command' RUNNING"
+  
+  actual_output=$(npm run $test_command 2>&1)
+  
+  if [[ "$actual_output" == *"$expected_output"* ]]; then
+    log "Test $test_number: '$test_command' PASSED" "success"
+  else
+    log "Test $test_number: '$test_command' FAILED" "error"
+  fi
+}
 
-# Test 3: `npm run envtune:ts-module`
-echo -e $'\e[33m\n[test-all-scripts.sh] - Test 3: `npm run envtune:ts-module` RUNNING\e[0m'
-expected3="hushHushDev"
-output3=$(npm run envtune:ts-module 2>&1)
-if [[ "$output3" == *"$expected3"* ]]; then
-  echo -e $'\e[32m[test-all-scripts.sh] - Test 3: `npm run envtune:ts-module` PASSED\e[0m'
-else
-  echo -e $'\e[31m[test-all-scripts.sh] - Test 3: `npm run envtune:ts-module` FAILED\e[0m'
-fi
+# Run tests
+run_test 1 "envtune:default-envtunerc" "hushHushDev"
+run_test 2 "envtune:ts-es6" "hushHushDev"
+run_test 3 "envtune:ts-module" "hushHushDev"
+run_test 4 "envtune:js-module" "hushHushDev"
+run_test 5 "envtune:invalid-child-command" "Child process failed to execute"
+run_test 6 "envtune:force-non-zero-exit" "exited with code 1"
+run_test 7 "envtune:invalid-env-file" "Could not find '.envtunerc' file in custom path"
+run_test 8 "envtune:missing-e-flag" "is required to specify the environment name"
 
-# Test 4: `npm run envtune:js-module`
-echo -e $'\e[33m\n[test-all-scripts.sh] - Test 4: `npm run envtune:js-module` RUNNING\e[0m'
-expected4="hushHushDev"
-output4=$(npm run envtune:js-module 2>&1)
-if [[ "$output4" == *"$expected4"* ]]; then
-  echo -e $'\e[32m[test-all-scripts.sh] - Test 4: `npm run envtune:js-module` PASSED\e[0m'
-else
-  echo -e $'\e[31m[test-all-scripts.sh] - Test 4: `npm run envtune:js-module` FAILED\e[0m'
-fi
-
-# Test 5: `npm run envtune:invalid-child-command`
-echo -e $'\e[33m\n[test-all-scripts.sh] - Test 5: `npm run envtune:invalid-child-command` RUNNING\e[0m'
-expected5="Child process failed to execute"
-output5=$(npm run envtune:invalid-child-command 2>&1)
-if [[ "$output5" == *"$expected5"* ]]; then
-  echo -e $'\e[32m[test-all-scripts.sh] - Test 5: `npm run envtune:invalid-child-command` PASSED\e[0m'
-else
-  echo -e $'\e[31m[test-all-scripts.sh] - Test 5: `npm run envtune:invalid-child-command` FAILED\e[0m'
-fi
-
-# Test 6: `npm run envtune:force-non-zero-exit`
-echo -e $'\e[33m\n[test-all-scripts.sh] - Test 6: `npm run envtune:force-non-zero-exit` RUNNING\e[0m'
-expected6="exited with code 1"
-output6=$(npm run envtune:force-non-zero-exit 2>&1)
-if [[ "$output6" == *"$expected6"* ]]; then
-  echo -e $'\e[32m[test-all-scripts.sh] - Test 6: `npm run envtune:force-non-zero-exit` PASSED\e[0m'
-else
-  echo -e $'\e[31m[test-all-scripts.sh] - Test 6: `npm run envtune:force-non-zero-exit` FAILED\e[0m'
-fi
-
-# Test 7: `npm run envtune:invalid-env-file`
-echo -e $'\e[33m\n[test-all-scripts.sh] - Test 7: `npm run envtune:invalid-env-file` RUNNING\e[0m'
-expected7="Could not find '.envtunerc' file in custom path"
-output7=$(npm run envtune:invalid-env-file 2>&1)
-if [[ "$output7" == *"$expected7"* ]]; then
-  echo -e $'\e[32m[test-all-scripts.sh] - Test 7: `npm run envtune:invalid-env-file` PASSED\e[0m'
-else
-  echo -e $'\e[31m[test-all-scripts.sh] - Test 7: `npm run envtune:invalid-env-file` FAILED\e[0m'
-fi
-
-# Test 8: `npm run envtune:missing-e-flag`
-echo -e $'\e[33m\n[test-all-scripts.sh] - Test 8: `npm run envtune:missing-e-flag` RUNNING\e[0m'
-expected8="is required to specify the environment name"
-output8=$(npm run envtune:missing-e-flag 2>&1)
-if [[ "$output8" == *"$expected8"* ]]; then
-  echo -e $'\e[32m[test-all-scripts.sh] - Test 8: `npm run envtune:missing-e-flag` PASSED\e[0m'
-else
-  echo -e $'\e[31m[test-all-scripts.sh] - Test 8: `npm run envtune:missing-e-flag` FAILED\e[0m'
-fi
+log "Execution completed" "" "standout"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "envtune",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "envtune",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.3.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "jest"
+    "test-jest": "jest",
+    "example-repo-install": "cd example && npm run install-local-package && npm install",
+    "example-repo-run-test-scripts": "cd example && npm run install-local-package && npm run test-all-scripts",
+    "publish-new-version": "./scripts/publish-new-version.sh"
   },
   "keywords": [
     "envtune",

--- a/scripts/log-to-terminal.sh
+++ b/scripts/log-to-terminal.sh
@@ -1,0 +1,31 @@
+log() {
+  local message=$1
+  local color=$2
+  local standout=$3
+  local filename=$(basename $0)
+  
+  if [[ "$standout" == "standout" ]]; then
+    echo $'\e[34m'"--------------------------------------------------------------------------------------------"
+    echo "[ $filename ] $message"
+    echo "--------------------------------------------------------------------------------------------"
+    echo $'\e[0m'
+  else
+    case $color in
+      error)
+        echo "[ $filename ] "$'\e[31m'"$message"$'\e[0m'
+        ;;
+      success)
+        echo "[ $filename ] "$'\e[32m'"$message"$'\e[0m'
+        ;;
+      *)
+        echo "[ $filename ] "$'\e[33m'"$message"$'\e[0m'
+        ;;
+    esac
+  fi
+}
+
+# Usage examples:
+# log "info message"
+# log "success message" "success"
+# log "error message" "error"
+# log "Standout message" "" 1

--- a/scripts/publish-new-version.sh
+++ b/scripts/publish-new-version.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+source ./scripts/log-to-terminal.sh
+
+log "Executing" "" "standout"
+
+# Exit script if any command fails
+set -e
+
+# Prompt user to enter semantic versioning type
+log "Current version: "v$(node -p "require('./package.json').version")""
+log "Enter new semantic version type (major, minor, patch):"
+read version_type
+
+# Validate user input
+if [[ "$version_type" != "major" && "$version_type" != "minor" && "$version_type" != "patch" ]]; then
+  log "Invalid version type. Exiting." "error"
+  exit 1
+fi
+
+# Run tests
+log "Running tests"
+npm run test-jest
+npm run example-repo-run-test-scripts
+
+# Build the package
+log "Running build"
+npm run build
+
+# Update package.json version without committing and tagging
+log "Updating npm version"
+npm version $version_type --no-git-tag-version --force
+
+# Commit the version change (affects package and package-lock jsons)
+log "Committing version change"
+git add .
+new_version_tag="v$(node -p "require('./package.json').version")"
+git commit -m "Bump version to $new_version_tag"
+
+# Push the new tag to GitHub
+log "Ready to push all files and new version tag to GitHub: "$new_version_tag""
+log "WARNING! Pushing a new version tag to GitHub will activate the 'publish-to-npm' automated workflow. Are you certain you want to proceed? (yes, no):"
+read is_certain
+
+# Validate user input
+if [[ "$is_certain" == "yes" ]]; then
+  log "Tagging new version"
+  git tag "$new_version_tag"
+  log "Pushing files to GitHub"
+  git push
+  log "Pushing new version tag to GitHub: "$new_version_tag""
+  git push origin "$new_version_tag"
+else
+  log "Publishing new version aborted" "error"
+  log "Reverting changes"
+  git reset HEAD~1 --hard
+  exit 1
+fi
+
+log "Execution completed" "" "standout"


### PR DESCRIPTION
Add CI/CD process for publishing a new entune package version to the NPM registry. Automated via bash scripts and github actions / workflows.